### PR TITLE
Can we update the upgrade command displayed in terminal

### DIFF
--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -42,7 +42,7 @@ BREW_DEPRECATION_MSG = (
     "brew uninstall cumulusci-plus\nbrew install pipx\npipx ensurepath\npipx install cumulusci-plus"
 )
 PIP_UPDATE_CMD = "pip install --upgrade cumulusci-plus"
-PIPX_UPDATE_CMD = "pipx upgrade cumulusci-plus"
+PIPX_UPDATE_CMD = "pipx install cumulusci-plus-azure-devops --include-deps --force"
 
 
 def parse_api_datetime(value):


### PR DESCRIPTION
When users need to upgrade CCI because of cumulus.yml file requireing higher version, can we update the upgrade command displayed in the terminal with the exact one we need? Otherwise its confusing for developers.